### PR TITLE
Add compatibility for drf 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,6 @@ jobs:
           # which has been moved to django.core.exceptions as of Django 3.1
           - django-version: "3.1"
             drf-version: "3.10"
-          # DRF "3.12" still causes TokenProxy TypeErrors
-          - drf-version: "3.12"
 
     steps:
       - name: Checkout Code

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If your project uses an older verison of Django or Django Rest Framework, you ca
 
 | This Project | Python Version | Django Version | Django Rest Framework |
 |--------------|----------------|----------------|-----------------------|
-| 1.4.*        | 3.5+           | 2.2+, 3.0+     | 3.9, 3.10, 3.11       |
+| 1.4.*        | 3.5+           | 2.2+, 3.0+     | 3.9, 3.10, 3.11, 3.12 |
 | 1.3.*        | 2.7, 3.4+      | 1.11, 2.0+     | 3.6, 3.7, 3.8         |
 | 1.2.*        | 2.7, 3.4+      | 1.8, 1.11, 2.0+| 3.6, 3.7, 3.8         |
 

--- a/django_rest_multitokenauth/models.py
+++ b/django_rest_multitokenauth/models.py
@@ -1,7 +1,6 @@
 import binascii
 import os
 
-from rest_framework.authtoken.models import Token
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _

--- a/django_rest_multitokenauth/views.py
+++ b/django_rest_multitokenauth/views.py
@@ -54,15 +54,14 @@ class LoginAndObtainAuthToken(APIView):
     renderer_classes = (renderers.JSONRenderer,)
     serializer_class = AuthTokenSerializer
 
-
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
         # fire pre_auth signal
         pre_auth.send(
             sender=self.__class__,
-            username=serializer.data['username'],
-            password=serializer.data['password']
+            username=request.data['username'],
+            password=request.data['password']
         )
 
         user = serializer.validated_data['user']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-Django==2.2.*
-djangorestframework==3.9.*
-django-ipware==2.1.*

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,0 @@
-Django==2.2.*
-djangorestframework==3.9.*
-django-ipware==2.1.*

--- a/tests/test.py
+++ b/tests/test.py
@@ -4,19 +4,8 @@ from django.db.models import Q
 from rest_framework import status
 from rest_framework.test import APITestCase
 from django_rest_multitokenauth.models import MultiToken
-try:
-    from unittest.mock import patch
-except:
-    # Python 2.7 fallback
-    from mock import patch
-
-# try getting reverse from django.urls
-try:
-    # Django 1.10 +
-    from django.urls import reverse
-except:
-    # Django 1.8 and 1.9
-    from django.core.urlresolvers import reverse
+from unittest.mock import patch
+from django.urls import reverse
 
 
 class HelperMixin:


### PR DESCRIPTION
The `pre_auth` signal was using serializer data which was changed to `write_only` with the release of `drf 3.12`. The behavior was changed and it now uses the data directly from the request.